### PR TITLE
chore: Update LICENSE initial year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Marcin Różewski, Amarokelab. All rights reserved.
+Copyright (c) 2023-2025 Marcin Różewski, Amarokelab
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Now, the year in the LICENSE file is the same as iy should have been at the very beginning of creating this reposiotry.